### PR TITLE
Set some objects to readonly

### DIFF
--- a/src/lib/CoreComponent.ts
+++ b/src/lib/CoreComponent.ts
@@ -2,7 +2,7 @@ import Disposable from 'seng-disposable/lib/Disposable';
 import ICoreComponent from './interface/ICoreComponent';
 
 export default class CoreComponent extends Disposable implements ICoreComponent {
-  public element: HTMLElement;
+  public readonly element: HTMLElement;
 
   constructor(element: HTMLElement) {
     super();
@@ -33,13 +33,7 @@ export default class CoreComponent extends Disposable implements ICoreComponent 
   public getElements<T extends Element = HTMLElement>(
     selector: string,
     container: HTMLElement = this.element,
-  ): Array<T> {
+  ): ReadonlyArray<T> {
     return Array.from(container.querySelectorAll(selector));
-  }
-
-  dispose() {
-    this.element = null;
-
-    super.dispose();
   }
 }

--- a/src/lib/interface/ICoreComponent.ts
+++ b/src/lib/interface/ICoreComponent.ts
@@ -1,7 +1,7 @@
 import IDisposable from 'seng-disposable/lib/IDisposable';
 
 interface ICoreComponent extends IDisposable {
-  element: HTMLElement;
+  readonly element: HTMLElement;
 
   /**
    * @public
@@ -19,7 +19,10 @@ interface ICoreComponent extends IDisposable {
    * @param {HTMLElement} container
    * @returns {Array<HTMLElement>}
    */
-  getElements<T extends Element = HTMLElement>(selector: string, container?: HTMLElement): Array<T>;
+  getElements<T extends Element = HTMLElement>(
+    selector: string,
+    container?: HTMLElement,
+  ): ReadonlyArray<T>;
 }
 
 export default ICoreComponent;


### PR DESCRIPTION
For more strictness and stability the `element` property of the CoreComponent should be `readonly` since it should not be possible to change this. Also the return value of the `getElements()` function should be a `ReadonlyArray`, because when this list is changes it does no longer reflect the actual DOM.

Changes:
- Change `element` of `CoreComponent` to be `readonly`
- Let `getElements()` return a `ReadonlyArray`