### PR TITLE
bump version to 2.0.0 due to breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muban-core",
-  "version": "1.13.1",
+  "version": "2.0.0",
   "description": "The core library and webpack loaders for Muban",
   "main": "./index.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
We merged a fix for CoreComponent's getElement to include null in the return a while back but didn't change the version. That change was a breaking change since TS will now complain about possibly null elements. This bumps it to 2.0.0.