### PR TITLE
Check readyState before listening to DOMContentLoaded event

### DIFF
--- a/src/lib/dist.ts
+++ b/src/lib/dist.ts
@@ -9,18 +9,29 @@ export type BootstrapOptions = {
   onBeforeInit?: () => void;
 };
 
-export function bootstrap(appRoot: HTMLElement, options: BootstrapOptions = {}) {
-  document.addEventListener('DOMContentLoaded', () => {
-    // most of the time this should already be the case, but to be sure we check if all sheets are loaded
-    waitForLoadedStyleSheets(document).then(() => {
-      // before initing components, to be compatible with dev mode
-      options.onBeforeInit?.();
+export async function bootstrap(
+  appRoot: HTMLElement,
+  options: BootstrapOptions = {},
+): Promise<void> {
+  await new Promise<void>((resolve) => {
+    // Check the readyState to check if it's necessary to listen to the DOMContentLoaded event
+    if (document.readyState !== 'loading') {
+      resolve();
+      return;
+    }
 
-      // Makes the website interactive, all hbs components are already loaded and registered, since they
-      // are included in the webpack entry
-      initComponents(appRoot);
-
-      options.onInit?.();
-    });
+    document.addEventListener('DOMContentLoaded', () => resolve());
   });
+
+  // most of the time this should already be the case, but to be sure we check if all sheets are loaded
+  await waitForLoadedStyleSheets(document);
+
+  // before initing components, to be compatible with dev mode
+  options.onBeforeInit?.();
+
+  // Makes the website interactive, all hbs components are already loaded and registered, since they
+  // are included in the webpack entry
+  initComponents(appRoot);
+
+  options.onInit?.();
 }

--- a/src/lib/utils/waitForStyleSheetsLoaded.ts
+++ b/src/lib/utils/waitForStyleSheetsLoaded.ts
@@ -4,8 +4,8 @@
  * @param document - the html document
  * @param dev - if in dev mode, it will only check 'blob' urls that are injected by style loaders
  */
-export const waitForLoadedStyleSheets = (document, development = false) =>
-  new Promise((resolve) => {
+export const waitForLoadedStyleSheets = (document: Document, development = false): Promise<void> =>
+  new Promise<void>((resolve) => {
     const links = Array.from<HTMLLinkElement>(
       // eslint-disable-next-line no-restricted-properties
       document.querySelectorAll('link[rel=stylesheet]'),


### PR DESCRIPTION
Muban is sometimes used in an environment where the markup and script tag to load the js bundle are not part of the document. This means that the DOMContentLoaded event is never invoked.